### PR TITLE
Separated kill & nuke options

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,27 +28,28 @@ function launchChrome(uri, opts) {
     env: opts.env || process.env
   })
 
-  // don't remove tmp dir automatically if
-  // supplied a custom one, don't want it getting
-  // nuked unknowingly!
-  if (!opts.dir || opts.nuke) {
-    process.on('exit', onClose)
-    process.on('close', onClose)
-    ps.on('close', onClose)
-  }
+  process.on('exit', onClose)
+  process.on('close', onClose)
+  ps.on('close', onClose)
 
   return ps
 
   function onClose() {
     if (closed) return; closed = true
-    ps.kill()
+    if (opts.kill == null || opts.kill)
+      ps.kill()
     process.removeListener('exit', onClose)
     process.removeListener('close', onClose)
 
-    try {
-      rimraf.sync(tmp)
-    } catch(e) {
-      rimraf.sync(tmp)
+    // don't remove tmp dir automatically if
+    // supplied a custom one, don't want it getting
+    // nuked unknowingly!
+    if (!opts.dir || opts.nuke) {
+      try {
+        rimraf.sync(tmp)
+      } catch(e) {
+        rimraf.sync(tmp)
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chrome-launch",
-  "version": "1.1.3",
+  "version": "1.1.3-patch.1",
   "description": "Light cross-platform launcher for Google Chrome",
   "main": "index.js",
   "license": "MIT",


### PR DESCRIPTION
The `nuke` option currently specifies whether to nuke the temp profile directory _and_ whether to kill the process. I split this to two options, a new `kill` option that specifies whether to kill the process and the original `nuke` option which now only controls the nuking of the temp profile directory.

Side-note: it's unclear from the readme that `nuke: false` only has an effect if an explicit `dir` is passed. This behavior surprised me, so it might be good to document.
