### PR TITLE
Add CLI wrapper

### DIFF
--- a/bin/chrome-launch
+++ b/bin/chrome-launch
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+
+const program = require('commander')
+const launchChrome = require('../')
+const pkg = require('../package.json')
+
+program
+  .version(pkg.version)
+  .usage('[options] <url> -- [args]')
+  .option('--dir <path>', 'user configuration directory to use. By default, one will be created and then removed when the process is killed')
+  .option('--nuke', 'remove `dir` when the process exits')
+
+program.on('--help', function () {
+  console.log('  Arguments:')
+  console.log('')
+  console.log('    [args] are additional command-line arguments to pass to Chrome. See here for a full list:')
+  console.log('    http://peter.sh/experiments/chromium-command-line-switches/')
+  console.log('')
+  console.log('  Examples:')
+  console.log('')
+  console.log('    This demonstrates how to load an unpacked extension into an isolated instance of Chrome without same-origin checking:')
+  console.log('')
+  console.log('    chrome-launch https://domain.tld/path -- --load-extension=path/to/extension --disable-web-security')
+})
+program.parse(process.argv)
+
+const {dir, nuke, args: [url = '', ...args]} = program
+launchChrome(url, {dir, nuke, args})

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.1.4",
   "description": "Light cross-platform launcher for Google Chrome",
   "main": "index.js",
+  "bin": "bin/chrome-launch",
   "license": "MIT",
   "author": {
     "name": "Hugh Kennedy",
@@ -22,6 +23,7 @@
   },
   "dependencies": {
     "chrome-location": "^1.2.0",
+    "commander": "^2.9.0",
     "quick-tmp": "0.0.0",
     "rimraf": "^2.2.8",
     "shallow-copy": "0.0.1"


### PR DESCRIPTION
Hi @hughsk, thanks for the module! I've been using it to automate my
browser extension development workflow, and it's saved me a lot of time.

Something that would make it even easier to use is a command-line
interface, so I added one and thought I'd see if you're interested in
pulling it in.

Run `bin/chrome-launch -h` to see how it works. Let me know if you have
any questions. Thanks!