### PR TITLE
fix no-translations chrome flag not working

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ function launchChrome(uri, opts) {
       uri
     , '--no-first-run'
     , '--no-default-browser-check'
-    , '--disable-translate'
+    , '--disable-features=Translate'
     , '--disable-default-apps'
     , '--disable-popup-blocking'
     , '--disable-zero-browsers-open-for-tests'


### PR DESCRIPTION
--no-translations flag is not working, because Google updated the flag name.

I know this repo is old, but people are still downloading this package.

Taken from here -> https://github.com/GoogleChrome/chrome-launcher/blob/master/src/flags.ts